### PR TITLE
feat: add functional query editor with prettifying in UI

### DIFF
--- a/src/__tests__/Body.mounted.test.tsx
+++ b/src/__tests__/Body.mounted.test.tsx
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import Body from '@/components/Body';
+
+function enc(s: string) {
+  return btoa(unescape(encodeURIComponent(s)))
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+}
+
+describe('Body mounted guard', () => {
+  it('restores from #b= and shows non-zero indicators after mount', async () => {
+    const raw = '{"a":1}';
+    window.location.hash = `b=${enc(raw)}`;
+
+    render(<Body />);
+
+    const ta = await screen.findByPlaceholderText('Raw request body');
+    expect((ta as HTMLTextAreaElement).value).toBe(raw);
+
+    const btn = screen.getByRole('button', { name: /Prettify/i });
+    expect(btn).not.toBeDisabled();
+
+    const bytesText = screen.getByText(/bytes$/i).textContent!;
+    const linesText = screen.getByText(/lines$/i).textContent!;
+    const bytes = Number(bytesText.match(/\d+/)![0]);
+    const lines = Number(linesText.match(/\d+/)![0]);
+    expect(bytes).toBeGreaterThan(0);
+    expect(lines).toBeGreaterThan(0);
+  });
+});

--- a/src/__tests__/Body.test.tsx
+++ b/src/__tests__/Body.test.tsx
@@ -1,0 +1,71 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import Body from '@/components/Body';
+
+function decodeB64Url(b: string) {
+  b = b.replace(/-/g, '+').replace(/_/g, '/');
+  while (b.length % 4) b += '=';
+  return decodeURIComponent(escape(atob(b)));
+}
+function encodeB64Url(s: string) {
+  return btoa(unescape(encodeURIComponent(s)))
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+}
+
+describe('Body', () => {
+  beforeEach(() => {
+    window.location.hash = '';
+    vi.spyOn(window, 'alert').mockImplementation(() => {});
+  });
+
+  it('restores from #b= after mount', async () => {
+    const raw = '{"a":1}';
+    window.location.hash = `b=${encodeB64Url(raw)}`;
+    render(<Body />);
+    const ta = await screen.findByPlaceholderText('Raw request body');
+    expect((ta as HTMLTextAreaElement).value).toBe(raw);
+  });
+
+  it('writes to #b= on blur', async () => {
+    render(<Body />);
+    const ta = await screen.findByPlaceholderText('Raw request body');
+    fireEvent.change(ta, { target: { value: '{"a":2}' } });
+    fireEvent.blur(ta);
+    const hash = window.location.hash.replace(/^#/, '');
+    const b = hash
+      .split('&')
+      .find((p) => p.startsWith('b='))!
+      .split('=')[1];
+    expect(decodeB64Url(b)).toBe('{"a":2}');
+  });
+
+  it('prettify formats json and keeps focus', async () => {
+    render(<Body />);
+    const ta = await screen.findByPlaceholderText('Raw request body');
+    fireEvent.change(ta, { target: { value: '{"a":1}' } });
+    const btn = screen.getByRole('button', { name: /Prettify/i });
+    fireEvent.click(btn);
+    expect((ta as HTMLTextAreaElement).value).toBe('{\n  "a": 1\n}');
+    expect(document.activeElement).toBe(ta);
+  });
+
+  it('disables prettify for non-json', async () => {
+    render(<Body />);
+    const ta = await screen.findByPlaceholderText('Raw request body');
+    fireEvent.change(ta, { target: { value: 'hello' } });
+    const btn = screen.getByRole('button', { name: /Prettify/i });
+    expect(btn).toBeDisabled();
+  });
+
+  it('updates indicators', async () => {
+    render(<Body />);
+    const ta = await screen.findByPlaceholderText('Raw request body');
+    fireEvent.change(ta, { target: { value: '{"a":1}' } });
+    await waitFor(() => {
+      expect(screen.getByText(/bytes$/i).textContent).toMatch(/\d+ bytes/);
+      expect(screen.getByText(/lines$/i).textContent).toMatch(/\d+ lines/);
+    });
+  });
+});

--- a/src/__tests__/base64url.extra.test.ts
+++ b/src/__tests__/base64url.extra.test.ts
@@ -1,0 +1,11 @@
+import { describe, it, expect } from 'vitest';
+import { encodeBase64Url, decodeBase64Url } from '@/utils/base64url';
+
+describe('base64url edge cases', () => {
+  it('decodes missing padding correctly', () => {
+    expect(decodeBase64Url('YQ')).toBe('a');
+  });
+  it('encodes/decodes empty string', () => {
+    expect(decodeBase64Url(encodeBase64Url(''))).toBe('');
+  });
+});

--- a/src/__tests__/base64url.test.ts
+++ b/src/__tests__/base64url.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { encodeBase64Url, decodeBase64Url } from '@/utils/base64url';
+
+describe('base64url', () => {
+  it('roundtrips ascii', () => {
+    const s = '{"a":1}';
+    const enc = encodeBase64Url(s);
+    expect(enc).not.toContain('+');
+    expect(enc).not.toContain('/');
+    expect(enc.endsWith('=')).toBe(false);
+    expect(decodeBase64Url(enc)).toBe(s);
+  });
+  it('roundtrips unicode', () => {
+    const s = 'привет {"a":1}';
+    const enc = encodeBase64Url(s);
+    expect(decodeBase64Url(enc)).toBe(s);
+  });
+});

--- a/src/__tests__/hashParams.test.ts
+++ b/src/__tests__/hashParams.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  readHash,
+  writeHash,
+  getHashParam,
+  setHashParam,
+} from '@/utils/hashParams';
+
+describe('hashParams', () => {
+  beforeEach(() => {
+    window.location.hash = '';
+  });
+
+  it('read/write', () => {
+    writeHash({ a: '1', b: '2' });
+    expect(readHash()).toEqual({ a: '1', b: '2' });
+  });
+
+  it('get/set', () => {
+    window.location.hash = 'a=1';
+    expect(getHashParam('a')).toBe('1');
+    setHashParam('b', '2');
+    expect(getHashParam('b')).toBe('2');
+    expect(readHash()).toEqual({ a: '1', b: '2' });
+  });
+});

--- a/src/__tests__/profiles.test.ts
+++ b/src/__tests__/profiles.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import * as mod from '@/constants/profiles';
+
+type ProfilesModule = { default?: unknown } & Record<string, unknown>;
+
+function getData(m: ProfilesModule): unknown {
+  return 'default' in m ? m.default : m;
+}
+
+function isRecord(x: unknown): x is Record<string, unknown> {
+  return typeof x === 'object' && x !== null && !Array.isArray(x);
+}
+
+describe('profiles constants', () => {
+  it('loads and exposes non-empty data', () => {
+    const data = getData(mod as ProfilesModule);
+
+    if (Array.isArray(data)) {
+      expect(data.length).toBeGreaterThan(0);
+      for (let i = 0; i < Math.min(3, data.length); i++) {
+        void data[i];
+      }
+    } else if (isRecord(data)) {
+      const keys = Object.keys(data).filter((k) => k !== '__esModule');
+      expect(keys.length).toBeGreaterThan(0);
+      for (let i = 0; i < Math.min(3, keys.length); i++) {
+        void data[keys[i]];
+      }
+    } else {
+      expect.fail('profiles exports neither an array nor an object');
+    }
+  });
+});

--- a/src/app/client/page.tsx
+++ b/src/app/client/page.tsx
@@ -1,0 +1,11 @@
+'use client';
+import Body from '@/components/Body';
+
+export default function ClientPage() {
+  return (
+    <main className="bg-base-300 min-h-screen p-4 md:p-8">
+      <h1 className="mb-4 text-2xl">REST Client</h1>
+      <Body />
+    </main>
+  );
+}

--- a/src/components/Body.tsx
+++ b/src/components/Body.tsx
@@ -1,0 +1,87 @@
+'use client';
+import { useMemo, useState, useCallback, useRef, useEffect } from 'react';
+import { encodeBase64Url, decodeBase64Url } from '@/utils/base64url';
+import { getHashParam, setHashParam } from '@/utils/hashParams';
+
+function bytesOf(text: string): number {
+  return new Blob([text]).size;
+}
+
+function linesOf(text: string): number {
+  if (!text) return 0;
+  return text.split(/\r?\n/).length;
+}
+
+function looksLikeJson(text: string): boolean {
+  const t = text.trim();
+  if (!t) return false;
+  const first = t[0];
+  return first === '{' || first === '[';
+}
+
+export default function Body() {
+  const [value, setValue] = useState<string>('');
+  const [mounted, setMounted] = useState(false);
+  const taRef = useRef<HTMLTextAreaElement | null>(null);
+
+  useEffect(() => {
+    setMounted(true);
+    const b = getHashParam('b');
+    if (!b) return;
+    try {
+      setValue(decodeBase64Url(b));
+    } catch {
+      setValue('');
+    }
+  }, []);
+
+  const sizeBytes = useMemo(() => bytesOf(value), [value]);
+  const lineCount = useMemo(() => linesOf(value), [value]);
+  const canPrettify = useMemo(() => looksLikeJson(value), [value]);
+
+  const handleBlur = useCallback(() => {
+    const encoded = encodeBase64Url(value);
+    setHashParam('b', encoded);
+  }, [value]);
+
+  const handlePrettify = useCallback(() => {
+    try {
+      const obj = JSON.parse(value);
+      const pretty = JSON.stringify(obj, null, 2);
+      setValue(pretty);
+      taRef.current?.focus();
+    } catch {
+      alert('Это не JSON, форматирование недоступно');
+    }
+  }, [value]);
+
+  const shownBytes = mounted ? sizeBytes : 0;
+  const shownLines = mounted ? lineCount : 0;
+  const prettifyDisabled = !mounted || !canPrettify;
+
+  return (
+    <div className="flex flex-col gap-2">
+      <label className="text-sm font-medium">Body</label>
+      <textarea
+        ref={taRef}
+        className="min-h-56 w-full rounded-xl border p-3 font-mono text-sm"
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        onBlur={handleBlur}
+        placeholder="Raw request body"
+      />
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          onClick={handlePrettify}
+          disabled={prettifyDisabled}
+          className="rounded-xl border px-3 py-1 text-sm disabled:opacity-50"
+        >
+          Prettify
+        </button>
+        <span className="text-xs opacity-70">{shownBytes} bytes</span>
+        <span className="text-xs opacity-70">{shownLines} lines</span>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Body.tsx
+++ b/src/components/Body.tsx
@@ -39,6 +39,19 @@ export default function Body() {
   const lineCount = useMemo(() => linesOf(value), [value]);
   const canPrettify = useMemo(() => looksLikeJson(value), [value]);
 
+  const validationError = useMemo(() => {
+    if (!mounted) return '';
+    const t = value.trim();
+    if (!t) return '';
+    if (!looksLikeJson(t)) return '';
+    try {
+      JSON.parse(t);
+      return '';
+    } catch {
+      return 'Not valid JSON. Use only double quotes (") and no trailing commas/semicolon.';
+    }
+  }, [mounted, value]);
+
   const handleBlur = useCallback(() => {
     const encoded = encodeBase64Url(value);
     setHashParam('b', encoded);
@@ -51,24 +64,31 @@ export default function Body() {
       setValue(pretty);
       taRef.current?.focus();
     } catch {
-      alert('Это не JSON, форматирование недоступно');
+      const hints: string[] = [];
+      if (/'\s*:/.test(value) || /:\s*'/.test(value))
+        hints.push('Use only double quotes (").');
+      if (/,(\s*[}\]])/.test(value))
+        hints.push('Remove trailing comma before } or ].');
+      if (/;\s*$/.test(value)) hints.push('Remove semicolon at the end.');
+      alert('Not valid JSON.\n' + (hints.length ? hints.join('\n') : ''));
     }
   }, [value]);
 
   const shownBytes = mounted ? sizeBytes : 0;
   const shownLines = mounted ? lineCount : 0;
-  const prettifyDisabled = !mounted || !canPrettify;
+  const prettifyDisabled = !mounted || !canPrettify || !!validationError;
 
   return (
     <div className="flex flex-col gap-2">
       <label className="text-sm font-medium">Body</label>
       <textarea
         ref={taRef}
-        className="min-h-56 w-full rounded-xl border p-3 font-mono text-sm"
+        className={`min-h-56 w-full rounded-xl border p-3 font-mono text-sm ${validationError ? 'border-red-500 focus:ring-2 focus:ring-red-400 focus:outline-none' : ''}`}
         value={value}
         onChange={(e) => setValue(e.target.value)}
         onBlur={handleBlur}
         placeholder="Raw request body"
+        aria-invalid={!!validationError}
       />
       <div className="flex items-center gap-2">
         <button
@@ -82,6 +102,11 @@ export default function Body() {
         <span className="text-xs opacity-70">{shownBytes} bytes</span>
         <span className="text-xs opacity-70">{shownLines} lines</span>
       </div>
+      {validationError && (
+        <span className="text-lg font-semibold text-red-700">
+          {validationError}
+        </span>
+      )}
     </div>
   );
 }

--- a/src/hooks/useAuthExpiryRedirect.ts
+++ b/src/hooks/useAuthExpiryRedirect.ts
@@ -7,7 +7,7 @@ import { useRouter, usePathname } from 'next/navigation';
 
 const SKEW_MS = 3000;
 
-const PUBLIC_ROUTES = ['/auth/sign-in', '/auth/sign-up', '/404'];
+const PUBLIC_ROUTES = ['/auth/sign-in', '/auth-sign-up', '/404'];
 
 export function useAuthExpiryRedirect() {
   const router = useRouter();
@@ -25,8 +25,11 @@ export function useAuthExpiryRedirect() {
     const unsub = onIdTokenChanged(auth, async (user) => {
       clearTimer();
 
+      const allowClient =
+        pathname === '/client' || /^\/[a-z]{2}\/client$/.test(pathname);
+
       if (!user) {
-        if (!PUBLIC_ROUTES.includes(pathname)) {
+        if (!PUBLIC_ROUTES.includes(pathname) && !allowClient) {
           router.replace('/');
         }
         return;

--- a/src/utils/base64url.ts
+++ b/src/utils/base64url.ts
@@ -1,0 +1,16 @@
+export function encodeBase64Url(input: string): string {
+  const b64 =
+    typeof window === 'undefined'
+      ? Buffer.from(input, 'utf8').toString('base64')
+      : btoa(unescape(encodeURIComponent(input)));
+  return b64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
+}
+
+export function decodeBase64Url(input: string): string {
+  const b64 = input.replace(/-/g, '+').replace(/_/g, '/');
+  const pad = b64.length % 4 ? 4 - (b64.length % 4) : 0;
+  const b64p = b64 + '='.repeat(pad);
+  return typeof window === 'undefined'
+    ? Buffer.from(b64p, 'base64').toString('utf8')
+    : decodeURIComponent(escape(atob(b64p)));
+}

--- a/src/utils/hashParams.ts
+++ b/src/utils/hashParams.ts
@@ -1,0 +1,32 @@
+export type HashMap = Record<string, string>;
+
+export function readHash(): HashMap {
+  const raw = window.location.hash.replace(/^#/, '');
+  if (!raw) return {};
+  return raw.split('&').reduce<HashMap>((acc, pair) => {
+    const [k, v] = pair.split('=');
+    if (k) acc[decodeURIComponent(k)] = v ? decodeURIComponent(v) : '';
+    return acc;
+  }, {});
+}
+
+export function writeHash(next: HashMap): void {
+  const parts = Object.entries(next).map(
+    ([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v)}`
+  );
+  const hash = parts.join('&');
+  if (hash !== window.location.hash.replace(/^#/, '')) {
+    window.location.hash = hash;
+  }
+}
+
+export function getHashParam(key: string): string | undefined {
+  const map = readHash();
+  return map[key];
+}
+
+export function setHashParam(key: string, value: string): void {
+  const map = readHash();
+  map[key] = value;
+  writeHash(map);
+}

--- a/src/widgets/Header.tsx
+++ b/src/widgets/Header.tsx
@@ -36,6 +36,9 @@ export default function Header() {
       </div>
       <div className="buttons-block flex w-full flex-wrap items-center justify-center gap-2 md:flex-nowrap md:justify-end md:gap-5">
         <LanguageSwitcher />
+        <Link href="/client" className="btn btn-soft btn-primary rounded-sm">
+          Client
+        </Link>
         {!user && (
           <>
             <Link


### PR DESCRIPTION
**feat: implement body editor with base64url save on blur, restore on load, prettify, and indicators**


## 🏷️ Pull Request Naming Convention

- **Title of Pull Request** all inside should follow [Our Naming Convention](#our-naming-convention)

##### 🤝 Our Naming Convention :

- **Title of Pull Request:** `[feat|fix|refactor|chore|docs|style|test]:*`
- **Branches:** `[feat|fix|refactor|chore|docs|style|test]/*`
- **Commits:** `feat|fix|refactor|chore|docs|style|test: Present tense verb and short description of the commit `
- [x] I followed naming convention rules

## 📋 What type of PR is this? (check all applicable)

- [ ] Chore
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [x] Test

## 📝 Description

* Implement functional Body editor per spec:

* Controlled multiline textarea “Body”.

* Save body to URL hash as Base64URL on blur (#b=).

* Restore from #b= on load (moved to useEffect to avoid hydration mismatch).

* Prettify button for JSON (parse → stringify with indent, focus stays in textarea).

* Indicators: bytes (via Blob.size) and lines (split(/\r?\n/)).

* Disabled Prettify for non-JSON; alert on parse failure.


## 🎨 Deployment


## 🧪 Added/updated tests?

_We encourage you to keep the code coverage percentage at 80% and above._

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests have not been included_
- [ ] I need help with writing tests

### 🖼️ [optional] Screenshots
<img width="993" height="678" alt="Screenshot 2025-09-08 at 19 49 29" src="https://github.com/user-attachments/assets/d9d10f8a-db7b-4df1-af68-274a36ffdb94" />

<img width="1003" height="564" alt="Screenshot 2025-09-08 at 19 52 22" src="https://github.com/user-attachments/assets/614f1e7f-45b4-4aa2-a5b4-074f2ac15ebd" />
<img width="1043" height="670" alt="Screenshot 2025-09-08 at 19 52 07" src="https://github.com/user-attachments/assets/166920d8-e986-4b95-a8ff-7b6e4ea55a60" />
<img width="1021" height="568" alt="Screenshot 2025-09-09 at 16 37 09" src="https://github.com/user-attachments/assets/de4c5f3c-f086-429d-bb4a-e94cbd6b2a5a" />

### 💭 [optional] What gif best describes this PR or how it makes you feel?






